### PR TITLE
fix: Update ADR list in all Markdown files with a line matching `<!-- adrlog`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 set -e
 
 if [ -f .adr-dir ]; then
@@ -8,8 +9,11 @@ fi
 adr "$@"
 
 if [ -f .adr-dir ]; then
-  targetFile="$(grep -m 1 -l ./*.md -e '<\!-- adrlog')"
-  if [ -n "$targetFile" ]; then
-    adr-log -i "$targetFile" -d "$(cat .adr-dir)"
-  fi
+  files="$(grep -m 1 -l ./*.md -e '<\!-- adrlog')"
+
+  for targetFile in ${files}; do
+    if [ -n "${targetFile}" ]; then
+      adr-log -i "${targetFile}" -d "$(cat .adr-dir)"
+    fi
+  done
 fi


### PR DESCRIPTION
Added functionality for updating the ADR log in all files that contains a line matching `<!-- adrlog`.

Previously the code only allowed ADR log in a single file. If multiple files existed, the command would throw an exception